### PR TITLE
Added BeforeAfterFSDiffer. Will report changes in a directory.

### DIFF
--- a/beforeafter.go
+++ b/beforeafter.go
@@ -1,0 +1,63 @@
+package fsdiffer
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// The BeforeAfterFSDiffer is used to generate changes in a given directory
+// between two different points in time.
+type BeforeAfterFSDiffer struct {
+	dir    string
+	before map[string]fileInfo
+}
+
+// NewBeforeAfterFSDiffer creates a new BeforeAfterFSDiffer that will report
+// changes on the given directory.
+func NewBeforeAfterFSDiffer(dir string) *BeforeAfterFSDiffer {
+	return &BeforeAfterFSDiffer{dir: dir}
+}
+
+// Start will walk the provided directory, and record its state for use as the
+// before part of the changes returned by Diff.
+func (ba *BeforeAfterFSDiffer) Start() error {
+	if ba.before != nil {
+		return fmt.Errorf("start already called")
+	}
+	ba.before = make(map[string]fileInfo)
+	return filepath.Walk(ba.dir, fsWalker(ba.before))
+}
+
+// Diff will return any changes to the filesystem in the provided directory
+// since Start was called.
+//
+// To detect if a file was changed it checks the file's size and mtime (like
+// rsync does by default if no --checksum options is used)
+func (ba *BeforeAfterFSDiffer) Diff() (FSChanges, error) {
+	changes := FSChanges{}
+	after := make(map[string]fileInfo)
+	err := filepath.Walk(ba.dir, fsWalker(after))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, afterInfo := range after {
+		relpath, _ := filepath.Rel(ba.dir, afterInfo.Path)
+		sourceInfo, ok := ba.before[filepath.Join(ba.dir, relpath)]
+		if !ok {
+			changes = append(changes, &FSChange{Path: relpath, ChangeType: Added})
+		} else {
+			if sourceInfo.Size() != afterInfo.Size() || sourceInfo.ModTime().Before(afterInfo.ModTime()) {
+				changes = append(changes, &FSChange{Path: relpath, ChangeType: Modified})
+			}
+		}
+	}
+	for _, infoA := range ba.before {
+		relpath, _ := filepath.Rel(ba.dir, infoA.Path)
+		_, ok := after[filepath.Join(ba.dir, relpath)]
+		if !ok {
+			changes = append(changes, &FSChange{Path: relpath, ChangeType: Deleted})
+		}
+	}
+	return changes, nil
+}

--- a/beforeafter_test.go
+++ b/beforeafter_test.go
@@ -1,0 +1,113 @@
+package fsdiffer
+
+import (
+	"archive/tar"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// Do not test (at the moment) symlinks as every os needs a special syscall to set symlink times
+func TestBeforeAfterFSDiffer(t *testing.T) {
+	time1 := time.Now()
+	time2 := time.Now().Add(1 * time.Microsecond)
+	sourceFiles := []*buildFileInfo{
+		&buildFileInfo{path: "file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+		&buildFileInfo{path: "dir01", typeflag: tar.TypeDir, mode: 0755, atime: time1, mtime: time1},
+		&buildFileInfo{path: "dir01/file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+	}
+
+	tests := []struct {
+		sourceFiles     []*buildFileInfo
+		destFiles       []*buildFileInfo
+		expectedChanges FSChangesMap
+	}{
+		{
+			sourceFiles: sourceFiles,
+			destFiles: []*buildFileInfo{
+				&buildFileInfo{path: "file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+				&buildFileInfo{path: "dir01", typeflag: tar.TypeDir, mode: 0755, atime: time1, mtime: time1},
+				&buildFileInfo{path: "dir01/file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+			},
+			expectedChanges: FSChangesMap{},
+		},
+		{
+			sourceFiles: sourceFiles,
+			// dir01 mtime changed
+			destFiles: []*buildFileInfo{
+				&buildFileInfo{path: "file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+				&buildFileInfo{path: "dir01", typeflag: tar.TypeDir, mode: 0755, atime: time1, mtime: time2},
+				&buildFileInfo{path: "dir01/file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+			},
+			expectedChanges: FSChangesMap{"dir01": Modified},
+		},
+		{
+			sourceFiles: sourceFiles,
+
+			// file01 contents changed
+			destFiles: []*buildFileInfo{
+				&buildFileInfo{path: "file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hellohello"},
+				&buildFileInfo{path: "dir01", typeflag: tar.TypeDir, mode: 0755, atime: time1, mtime: time1},
+				&buildFileInfo{path: "dir01/file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+			},
+			expectedChanges: FSChangesMap{"file01": Modified},
+		},
+		{
+			sourceFiles: sourceFiles,
+			// new dir and file dir02/file01, dir01/file01 removed
+			destFiles: []*buildFileInfo{
+				&buildFileInfo{path: "file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+				&buildFileInfo{path: "dir02", typeflag: tar.TypeDir, mode: 0755, atime: time1, mtime: time1},
+				&buildFileInfo{path: "dir02/file01", typeflag: tar.TypeReg, mode: 0644, atime: time1, mtime: time1, contents: "hello"},
+			},
+			expectedChanges: FSChangesMap{
+				"dir01":        Deleted,
+				"dir01/file01": Deleted,
+				"dir02":        Added,
+				"dir02/file01": Added,
+			},
+		},
+	}
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	testDir := filepath.Join(dir, "test")
+
+	for _, tt := range tests {
+		os.RemoveAll(testDir)
+
+		err = buildFS(testDir, tt.sourceFiles)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		ba := NewBeforeAfterFSDiffer(testDir)
+		err = ba.Start()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		os.RemoveAll(testDir)
+		err = buildFS(testDir, tt.destFiles)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		changes, err := ba.Diff()
+		changesMap := changes.ToMap()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(changesMap) != len(tt.expectedChanges) {
+			t.Errorf("wrong changes size: want: %d, got: %d", len(tt.expectedChanges), len(changesMap))
+		}
+		if !reflect.DeepEqual(changesMap, tt.expectedChanges) {
+			t.Errorf("changes differs: want: %q, got: %q", printChanges(tt.expectedChanges), printChanges(changesMap))
+		}
+	}
+
+}


### PR DESCRIPTION
For acbuild I want to walk the filetree to take note of the filesystem,
allow the user provided command to do its things, and then walk it again
to take note of deleted files. The SimpleFSDiffer will report changes
between two different directories at a given point in time. This
introduces the BeforeAfterFSDiffer, which will report changes in a
single directory between two different points in time.
